### PR TITLE
test: add support for testing with Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
         houdini-version:
           - "19.5"  # Python 3.9
           - "20.0"  # Python 3.10
+          - "20.5"  # Python 3.11
 
     container:
       image: captainhammy/hython-runner:${{ matrix.houdini-version }}

--- a/.github/workflows/update-action-tag.yml
+++ b/.github/workflows/update-action-tag.yml
@@ -1,0 +1,22 @@
+name: Move Major Release Tag
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  movetag:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Get major version num and update tag
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/}
+        MAJOR=${VERSION%%.*}
+        git config --global user.name 'Graham Thompson'
+        git config --global user.email 'captainhammy@gmail.com'
+        git tag -fa ${MAJOR} -m "Update major version tag"
+        git push origin ${MAJOR} --force

--- a/install_rez_packages.py
+++ b/install_rez_packages.py
@@ -1,5 +1,8 @@
 """This script is used to install pip packages into rez."""
 
+# Future
+from __future__ import annotations
+
 # Standard Library
 import argparse
 import pathlib

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
-envlist = py310,py39,ruff-check,ruff-format-check,isort-check,mypy,docstring-check
+envlist = py311,py310,py39,ruff-check,ruff-format-check,isort-check,mypy,docstring-check
 skipsdist = true
 labels =
-    test = py310
+    test = py311
     static = ruff-check,ruff-format-check,isort-check,mypy,docstring-check
     fix = ruff-format-fix,isort-run,docstring-run
 
 [gh-actions]
 python =
+    3.11: py311, mypy, ruff-check, ruff-format-check, isort-check, docstring-check
     3.10: py310, mypy, ruff-check, ruff-format-check, isort-check, docstring-check
     3.9: py39, mypy, ruff-check, ruff-format-check, isort-check, docstring-check
 


### PR DESCRIPTION
This PR also adds an action to automatically bump the major version tag for the corresponding release.